### PR TITLE
images/trustx-cml-initramfs: Fix syntax for conditional append

### DIFF
--- a/images/trustx-cml-initramfs.bbappend
+++ b/images/trustx-cml-initramfs.bbappend
@@ -1,1 +1,1 @@
-PACKAGE_INSTALL:tqma8mpxl += "bootloader-loopdev"
+PACKAGE_INSTALL:append:tqma8mpxl = " bootloader-loopdev"


### PR DESCRIPTION
Conditional appending using '+=' overrides the complete PACKAGE_INSTALL variable and does therefore not work. Use ':append' instead.